### PR TITLE
fix several issues + add mdscale-based initialization

### DIFF
--- a/cmdscale.py
+++ b/cmdscale.py
@@ -1,0 +1,51 @@
+# thanks to Francis Song for this function
+# source: http://www.nervouscomputer.com/hfs/cmdscale-in-python/
+from __future__ import division
+ 
+import numpy as np
+ 
+def cmdscale(D):
+    """                                                                                       
+    Classical multidimensional scaling (MDS)                                                  
+                                                                                               
+    Parameters                                                                                
+    ----------                                                                                
+    D : (n, n) array                                                                          
+        Symmetric distance matrix.                                                            
+                                                                                               
+    Returns                                                                                   
+    -------                                                                                   
+    Y : (n, p) array                                                                          
+        Configuration matrix. Each column represents a dimension. Only the                    
+        p dimensions corresponding to positive eigenvalues of B are returned.                 
+        Note that each dimension is only determined up to an overall sign,                    
+        corresponding to a reflection.                                                        
+                                                                                               
+    e : (n,) array                                                                            
+        Eigenvalues of B.                                                                     
+                                                                                               
+    """
+    # Number of points                                                                        
+    n = len(D)
+ 
+    # Centering matrix                                                                        
+    H = np.eye(n) - np.ones((n, n))/n
+ 
+    # YY^T                                                                                    
+    B = -H.dot(D**2).dot(H)/2
+ 
+    # Diagonalize                                                                             
+    evals, evecs = np.linalg.eigh(B)
+ 
+    # Sort by eigenvalue in descending order                                                  
+    idx   = np.argsort(evals)[::-1]
+    evals = evals[idx]
+    evecs = evecs[:,idx]
+ 
+    # Compute the coordinates using positive-eigenvalued components only                      
+    w, = np.where(evals > 0)
+    L  = np.diag(np.sqrt(evals[w]))
+    V  = evecs[:,w]
+    Y  = V.dot(L)
+ 
+    return Y, evals[evals > 0]

--- a/sammon.py
+++ b/sammon.py
@@ -95,7 +95,6 @@ def sammon(x, n, display = 2, inputdist = 'raw', maxhalves = 20, maxiter = 500, 
     elif init == 'cmdscale':
         from cmdscale import cmdscale
         y,e = cmdscale(D)
-        print(y.shape)
         y = y[:,:n]
     else:
         y = np.random.normal(0.0,1.0,[N,n])

--- a/sammon.py
+++ b/sammon.py
@@ -105,7 +105,7 @@ def sammon(x, n = 2, display = 2, inputdist = 'raw', maxhalves = 20, maxiter = 5
 
         # Use step-halving procedure to ensure progress is made
         for j in range(maxhalves):
-            s_reshape = s.reshape(2,len(s)/2).T
+            s_reshape = np.reshape(s, (-1,n),order='F')
             y = y_old + s_reshape
             d = cdist(y, y) + np.eye(N)
             dinv = 1 / d

--- a/sammon.py
+++ b/sammon.py
@@ -74,16 +74,17 @@ def sammon(x, n, display = 2, inputdist = 'raw', maxhalves = 20, maxiter = 500, 
         if init == 'default':
             init = 'pca'
 
-    if np.count_nonzero(D<=0) > 0:
-        raise ValueError("Off-diagonal dissimilarities must be strictly positive")
-
     if inputdist == 'distance' and init == 'pca':
         raise ValueError("Cannot use init == 'pca' when inputdist == 'distance'")
 
     # Remaining initialisation
     N = x.shape[0]
     scale = 0.5 / D.sum()
-    D = D + np.eye(N)        
+    D = D + np.eye(N)     
+
+    if np.count_nonzero(D<=0) > 0:
+        raise ValueError("Off-diagonal dissimilarities must be strictly positive")   
+
     Dinv = 1 / D
     if init == 'pca':
         [UU,DD,_] = np.linalg.svd(x)

--- a/sammon.py
+++ b/sammon.py
@@ -79,8 +79,7 @@ def sammon(x, n = 2, display = 2, inputdist = 'raw', maxhalves = 20, maxiter = 5
     N = x.shape[0]
     scale = 0.5 / D.sum()
     D = D + np.eye(N)
-    Dinv = 1 / D # Returns inf where D = 0.
-    Dinv[np.isinf(Dinv)] = 0 # Fix by replacing inf with 0 (default Matlab behaviour).
+    Dinv = 1 / D
     if init == 'pca':
         [UU,DD,_] = np.linalg.svd(x)
         y = UU[:,:n]*DD[:n] 
@@ -88,8 +87,7 @@ def sammon(x, n = 2, display = 2, inputdist = 'raw', maxhalves = 20, maxiter = 5
         y = np.random.normal(0.0,1.0,[N,n])
     one = np.ones([N,n])
     d = euclid(y,y) + np.eye(N)
-    dinv = 1. / d # Returns inf where d = 0. 
-    dinv[np.isinf(dinv)] = 0 # Fix by replacing inf with 0 (default Matlab behaviour).
+    dinv = 1. / d
     delta = D-d 
     E = ((delta**2)*Dinv).sum() 
 
@@ -114,8 +112,7 @@ def sammon(x, n = 2, display = 2, inputdist = 'raw', maxhalves = 20, maxiter = 5
             s_reshape = s.reshape(2,len(s)/2).T
             y = y_old + s_reshape
             d = euclid(y, y) + np.eye(N)
-            dinv = 1 / d # Returns inf where D = 0. 
-            dinv[np.isinf(dinv)] = 0 # Fix by replacing inf with 0 (default Matlab behaviour).
+            dinv = 1 / d
             delta = D - d
             E_new = ((delta**2)*Dinv).sum()
             if E_new < E:

--- a/sammon.py
+++ b/sammon.py
@@ -72,8 +72,11 @@ def sammon(x, n = 2, display = 2, inputdist = 'raw', maxhalves = 20, maxiter = 5
     else:
         D = euclid(x,x)
 
+    if np.count_nonzero(D<=0) > 0:
+        raise ValueError("Off-diagonal dissimilarities must be strictly positive")
+
     # Remaining initialisation
-    N = x.shape[0] # hmmm, shape[1]?
+    N = x.shape[0]
     scale = 0.5 / D.sum()
     D = D + np.eye(N)
     Dinv = 1 / D # Returns inf where D = 0.
@@ -121,7 +124,7 @@ def sammon(x, n = 2, display = 2, inputdist = 'raw', maxhalves = 20, maxiter = 5
                 s = np.dot(0.5,s)
 
         # Bomb out if too many halving steps are required
-        if j == maxhalves:
+        if j == maxhalves-1:
             print('Warning: maxhalves exceeded. Sammon mapping may not converge...')
 
         # Evaluate termination criterion
@@ -133,7 +136,10 @@ def sammon(x, n = 2, display = 2, inputdist = 'raw', maxhalves = 20, maxiter = 5
         # Report progress
         E = E_new
         if display > 1:
-            print('epoch = ' + str(i) + ': E = ' + str(E * scale))
+            print('epoch = %d : E = %12.10f'% (i+1, E * scale))
+
+    if i == maxiter-1:
+        print('Warning: maxiter exceeded. Sammon mapping may not have converged...')
 
     # Fiddle stress to match the original Sammon paper
     E = E * scale

--- a/sammon.py
+++ b/sammon.py
@@ -77,6 +77,9 @@ def sammon(x, n, display = 2, inputdist = 'raw', maxhalves = 20, maxiter = 500, 
     if inputdist == 'distance' and init == 'pca':
         raise ValueError("Cannot use init == 'pca' when inputdist == 'distance'")
 
+    if np.count_nonzero(np.diagonal(D)) > 0:
+        raise ValueError("The diagonal of the dissimilarity matrix must be zero")
+
     # Remaining initialisation
     N = x.shape[0]
     scale = 0.5 / D.sum()

--- a/sammon.py
+++ b/sammon.py
@@ -1,6 +1,7 @@
 def sammon(x, n = 2, display = 2, inputdist = 'raw', maxhalves = 20, maxiter = 500, tolfun = 1e-9, init = 'pca'):
 
     import numpy as np 
+    from scipy.spatial.distance import cdist
 
     """Perform Sammon mapping on dataset x
 
@@ -61,16 +62,11 @@ def sammon(x, n = 2, display = 2, inputdist = 'raw', maxhalves = 20, maxiter = 5
 
     """
 
-    def euclid(a,b):
-        d = np.sqrt( ((a**2).sum(axis=1)*np.ones([1,b.shape[0]]).T).T + \
-            np.ones([a.shape[0],1])*(b**2).sum(axis=1)-2*(np.dot(a,b.T)))
-        return d
-
     # Create distance matrix unless given by parameters
     if inputdist == 'distance':
         D = x
     else:
-        D = euclid(x,x)
+        D = cdist(x, x)
 
     if np.count_nonzero(D<=0) > 0:
         raise ValueError("Off-diagonal dissimilarities must be strictly positive")
@@ -86,7 +82,7 @@ def sammon(x, n = 2, display = 2, inputdist = 'raw', maxhalves = 20, maxiter = 5
     else:
         y = np.random.normal(0.0,1.0,[N,n])
     one = np.ones([N,n])
-    d = euclid(y,y) + np.eye(N)
+    d = cdist(y,y) + np.eye(N)
     dinv = 1. / d
     delta = D-d 
     E = ((delta**2)*Dinv).sum() 
@@ -111,7 +107,7 @@ def sammon(x, n = 2, display = 2, inputdist = 'raw', maxhalves = 20, maxiter = 5
         for j in range(maxhalves):
             s_reshape = s.reshape(2,len(s)/2).T
             y = y_old + s_reshape
-            d = euclid(y, y) + np.eye(N)
+            d = cdist(y, y) + np.eye(N)
             dinv = 1 / d
             delta = D - d
             E_new = ((delta**2)*Dinv).sum()

--- a/sammon.py
+++ b/sammon.py
@@ -26,7 +26,7 @@ def sammon(x, n, display = 2, inputdist = 'raw', maxhalves = 20, maxiter = 500, 
        input          - {'raw','distance'} if set to 'distance', X is 
                         interpreted as a matrix of pairwise distances.
        display        - 0 to 2. 0 least verbose, 2 max verbose.
-       init           - {'pca', 'mdscale', random', 'default'}
+       init           - {'pca', 'cmdscale', random', 'default'}
                         default is 'pca' if input is 'raw', 
                         'msdcale' if input is 'distance'
 

--- a/sammon.py
+++ b/sammon.py
@@ -114,14 +114,14 @@ def sammon(x, n = 2, display = 2, inputdist = 'raw', maxhalves = 20, maxiter = 5
             if E_new < E:
                 break
             else:
-                s = np.dot(0.5,s)
+                s = 0.5*s
 
         # Bomb out if too many halving steps are required
         if j == maxhalves-1:
             print('Warning: maxhalves exceeded. Sammon mapping may not converge...')
 
         # Evaluate termination criterion
-        if np.abs((E - E_new) / E) < tolfun:
+        if abs((E - E_new) / E) < tolfun:
             if display:
                 print('TolFun exceeded: Optimisation terminated')
             break

--- a/sammontest.py
+++ b/sammontest.py
@@ -1,6 +1,6 @@
 def main():
 
-   import numpy as np 
+   import numpy as np
    from sklearn import datasets
    import matplotlib.pyplot as plt
    from sammon import sammon
@@ -26,12 +26,12 @@ def main():
    """
    # Load the iris data
    iris = datasets.load_iris()
-   X = iris.data
-   target = iris.target
+   (x,index) = np.unique(iris.data,axis=0,return_index=True)
+   target = iris.target[index]
    names = iris.target_names
 
    # Run the Sammon projection
-   [y,E] = sammon(X)
+   [y,E] = sammon(x, 2)
 
    # Plot
    plt.scatter(y[target ==0, 0], y[target ==0, 1], s=20, c='r', marker='o',label=names[0])


### PR DESCRIPTION
- restore original variable names to be consistent with the reference MATLAB version (https://github.com/tompollard/sammon/commit/b69b203b89b7bd322694fdae97a9033779d6140f)
- Sammon mapping is designed to run only if there are no duplicate data points, so sammontest removed duplicate data (https://github.com/tompollard/sammon/commit/e03ed608d3093ab78ee687e352cc0654e2b4aa7e)
- check that input data contains no duplicates (which result in zero elements in the dissimilarity matrix) and better error reporting (https://github.com/tompollard/sammon/commit/5d674cca78ad8b77d0d9c26234c8229e4fcaa446 https://github.com/tompollard/sammon/pull/8/commits/1e923246d69a321015e7269b0aa8e447a2b6e8c7 https://github.com/tompollard/sammon/pull/8/commits/8791d5958b1b99bbe0e6b5d2c808b7e3c0133988)
- remove hacks that set infinity values to 0 in the dissimilarity matrix (https://github.com/tompollard/sammon/commit/ed05bc67fa87ad396f14d03bd2c602b7ed40575c)
- use scipy.spatial.distance.cdist instead of euclid (from previous PR) (https://github.com/tompollard/sammon/pull/8/commits/a677473b9f767c8297f1c7a57e49cff40904156f)
- fix bug when n != 2 (https://github.com/tompollard/sammon/pull/8/commits/a5852922e3e169cb14645de9e27d417e6cb6f755)
- add support for cmdscale-based initialization, which can be used when the input is a dissimilarity matrix (https://github.com/tompollard/sammon/commit/21bbdd6a08e99c5f8cccd4bc44e1d4468234f552)